### PR TITLE
feat: database-backed whitelist with admin UI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,9 +3,10 @@ name: Docker Build
 on:
   push:
     branches:
-      - "**"
+      - main
     tags:
       - "*"
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,6 +26,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: voidic
@@ -44,7 +46,7 @@ jobs:
         with:
           context: .
           platforms: ${{ github.ref_type == 'tag' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,4 +67,5 @@ payments-rs = { git = "https://github.com/v0l/payments-rs.git", optional = true,
 
 [dev-dependencies]
 tempfile = "3"
+serde_json = "1"
 

--- a/config.yaml
+++ b/config.yaml
@@ -13,12 +13,16 @@ max_upload_bytes: 5e+9
 # Public facing url
 public_url: "http://localhost:8000"
 
-# (Optional) Whitelisted pubkeys, leave out to disable
+# (Optional) Whitelist — controls who may upload files. Leave out to allow everyone.
+#
+# Database-backed (managed via admin UI):
+# whitelist: true
+#
+# Inline static list of hex pubkeys:
 # whitelist: ["63fe6318dc58583cfe16810f86dd09e18bfd76aabc24a0081ce2856f330504ed"]
-
-# (Optional) Path to a whitelist file (one hex pubkey per line, '#' comments allowed)
-# If set, the server auto-reloads changes about every 10 seconds
-# whitelist_file: "./whitelist.txt"
+#
+# Hot-reloaded file (one hex pubkey per line, '#' comments allowed):
+# whitelist: "./whitelist.txt"
 
 # Directory where HuggingFace model files are cached.
 # Defaults to <storage_dir>/models when not set.
@@ -62,7 +66,7 @@ label_flag_terms:
 # (Optional) Payment system config
 # Remove this entire section to disable storage quotas and enable unlimited uploads
 payments:
-  # (Optional) Free quota in bytes for users without payments (default: 100MB) 
+  # (Optional) Free quota in bytes for users without payments (default: 100MB)
   free_quota_bytes: 104857600
   # (Optional) Fiat currency used to track exchange rate along with invoices
   # If [cost] is using a fiat currency, exchange rates will always be stored

--- a/migrations/20260311100000_whitelist.sql
+++ b/migrations/20260311100000_whitelist.sql
@@ -1,0 +1,9 @@
+-- Database-backed whitelist table.
+-- Each row represents a pubkey (hex) that is allowed to upload files.
+-- When whitelist enforcement is enabled (via settings or presence of rows),
+-- only pubkeys in this table (or the config/file whitelist) may upload.
+create table if not exists whitelist
+(
+    pubkey  varchar(64)  not null primary key,
+    created timestamp    not null default current_timestamp
+);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -20,7 +20,7 @@ use route96::db::Database;
 use route96::file_stats::FileStatsTracker;
 use route96::filesystem::FileStore;
 use route96::routes;
-use route96::settings::Settings;
+use route96::settings::{Settings, WhitelistMode};
 use route96::whitelist::Whitelist;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Error> {
     };
 
     let fs = FileStore::new(settings.clone());
-    let wl = Whitelist::new(settings.whitelist.clone());
+    let wl = Whitelist::from_mode(settings.whitelist.as_ref(), Some(&db));
     let file_stats = FileStatsTracker::new();
 
     #[cfg(feature = "payments")]
@@ -159,7 +159,7 @@ async fn main() -> Result<(), Error> {
         #[cfg(feature = "payments")]
         lnd.clone(),
     );
-    if let Some(path) = settings.whitelist_file.clone() {
+    if let Some(WhitelistMode::File(path)) = settings.whitelist.clone() {
         let wh = wl.start_file_watcher(path, shutdown.clone());
         jh.push(wh);
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -145,6 +145,12 @@ pub struct Payment {
 }
 
 #[derive(Clone, FromRow, Serialize)]
+pub struct WhitelistEntry {
+    pub pubkey: String,
+    pub created: DateTime<Utc>,
+}
+
+#[derive(Clone, FromRow, Serialize)]
 pub struct Report {
     pub id: u64,
     #[serde(with = "hex")]
@@ -713,6 +719,51 @@ impl Database {
 
         tx.commit().await?;
         Ok(())
+    }
+
+    // ── Database-backed whitelist ───────────────────────────────────────────
+
+    /// Add a pubkey (hex) to the database whitelist.
+    /// Uses `INSERT IGNORE` so calling this for an already-present pubkey is safe.
+    pub async fn whitelist_add(&self, pubkey_hex: &str) -> Result<(), Error> {
+        sqlx::query("insert ignore into whitelist(pubkey) values(?)")
+            .bind(pubkey_hex)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Remove a pubkey (hex) from the database whitelist.
+    pub async fn whitelist_remove(&self, pubkey_hex: &str) -> Result<(), Error> {
+        sqlx::query("delete from whitelist where pubkey = ?")
+            .bind(pubkey_hex)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Return all entries in the database whitelist, ordered by creation time.
+    pub async fn whitelist_list(&self) -> Result<Vec<WhitelistEntry>, Error> {
+        sqlx::query_as("select pubkey, created from whitelist order by created asc")
+            .fetch_all(&self.pool)
+            .await
+    }
+
+    /// Return true if `pubkey_hex` is present in the database whitelist.
+    pub async fn whitelist_contains(&self, pubkey_hex: &str) -> Result<bool, Error> {
+        let row = sqlx::query("select 1 from whitelist where pubkey = ?")
+            .bind(pubkey_hex)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.is_some())
+    }
+
+    /// Return true if the database whitelist has at least one entry.
+    pub async fn whitelist_is_enabled(&self) -> Result<bool, Error> {
+        let row = sqlx::query("select 1 from whitelist limit 1")
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(row.is_some())
     }
 
     /// Mark multiple reports as reviewed in a single query.

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -311,7 +311,6 @@ mod tests {
             max_upload_bytes: 0,
             public_url: String::new(),
             whitelist: None,
-            whitelist_file: None,
             models_dir: None,
             label_models: None,
             label_flag_terms: None,

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -1,5 +1,5 @@
 use crate::auth::nip98::Nip98Auth;
-use crate::db::{Database, FileUpload, FileUploadWithStats, Report, ReviewState, User};
+use crate::db::{Database, FileUpload, FileUploadWithStats, Report, ReviewState, User, WhitelistEntry};
 use crate::file_stats::FileStats;
 use crate::routes::{AppState, Nip94Event, PagedResult};
 use axum::{
@@ -28,7 +28,13 @@ pub fn admin_routes() -> Router<Arc<AppState>> {
         .route("/admin/reports", get(admin_list_reports))
         .route("/admin/reports", delete(admin_acknowledge_reports))
         .route("/admin/user/{user_pubkey}", get(admin_get_user_info))
-        .route("/admin/user/{user_pubkey}/purge", delete(admin_purge_user));
+        .route("/admin/user/{user_pubkey}/purge", delete(admin_purge_user))
+        .route(
+            "/admin/whitelist",
+            get(admin_list_whitelist)
+                .post(admin_add_whitelist)
+                .delete(admin_remove_whitelist),
+        );
 
     #[cfg(feature = "media-compression")]
     {
@@ -802,6 +808,13 @@ impl Database {
         Ok((res, count))
     }
 
+    // ── Database-backed whitelist queries ──────────────────────────────────
+
+    /// Return all entries in the database whitelist.
+    pub async fn list_whitelist_entries(&self) -> Result<Vec<WhitelistEntry>, Error> {
+        self.whitelist_list().await
+    }
+
     /// List files whose `review_state` is not `None` and not `Reviewed`,
     /// ordered oldest-first so the backlog drains naturally.
     pub async fn list_files_pending_review(
@@ -846,5 +859,65 @@ impl Database {
             })
             .collect();
         Ok((res, count))
+    }
+}
+
+// ── Whitelist admin handlers ────────────────────────────────────────────────
+
+/// GET /admin/whitelist — list all DB whitelist entries
+async fn admin_list_whitelist(
+    auth: Nip98Auth,
+    AxumState(state): AxumState<Arc<AppState>>,
+) -> AdminResponse<Vec<WhitelistEntry>> {
+    if let Err(e) = require_admin(&auth, &state.db).await {
+        return AdminResponse::error(&e);
+    }
+
+    match state.db.whitelist_list().await {
+        Ok(entries) => AdminResponse::success(entries),
+        Err(e) => AdminResponse::error(&format!("Failed to list whitelist: {}", e)),
+    }
+}
+
+/// Request body for adding/removing a pubkey from the whitelist.
+#[derive(Deserialize)]
+struct WhitelistPubkeyBody {
+    pubkey: String,
+}
+
+/// POST /admin/whitelist — add a pubkey to the DB whitelist
+async fn admin_add_whitelist(
+    auth: Nip98Auth,
+    AxumState(state): AxumState<Arc<AppState>>,
+    Json(body): Json<WhitelistPubkeyBody>,
+) -> AdminResponse<()> {
+    if let Err(e) = require_admin(&auth, &state.db).await {
+        return AdminResponse::error(&e);
+    }
+
+    // Validate: must be a 64-char hex string (32-byte pubkey)
+    if body.pubkey.len() != 64 || hex::decode(&body.pubkey).is_err() {
+        return AdminResponse::error("Invalid pubkey: must be a 64-character hex string");
+    }
+
+    match state.db.whitelist_add(&body.pubkey).await {
+        Ok(()) => AdminResponse::success(()),
+        Err(e) => AdminResponse::error(&format!("Failed to add to whitelist: {}", e)),
+    }
+}
+
+/// DELETE /admin/whitelist — remove a pubkey from the DB whitelist
+async fn admin_remove_whitelist(
+    auth: Nip98Auth,
+    AxumState(state): AxumState<Arc<AppState>>,
+    Json(body): Json<WhitelistPubkeyBody>,
+) -> AdminResponse<()> {
+    if let Err(e) = require_admin(&auth, &state.db).await {
+        return AdminResponse::error(&e);
+    }
+
+    match state.db.whitelist_remove(&body.pubkey).await {
+        Ok(()) => AdminResponse::success(()),
+        Err(e) => AdminResponse::error(&format!("Failed to remove from whitelist: {}", e)),
     }
 }

--- a/src/routes/blossom.rs
+++ b/src/routes/blossom.rs
@@ -148,8 +148,8 @@ fn check_method(event: &nostr::Event, method: &str) -> bool {
     false
 }
 
-fn check_whitelist(auth: &BlossomAuth, whitelist: &Whitelist) -> Option<BlossomResponse> {
-    if !whitelist.contains_hex(&auth.event.pubkey.to_hex()) {
+async fn check_whitelist(auth: &BlossomAuth, whitelist: &Whitelist) -> Option<BlossomResponse> {
+    if !whitelist.is_allowed(&auth.event.pubkey.to_hex()).await {
         return Some(BlossomResponse::Generic(BlossomGenericResponse {
             status: StatusCode::FORBIDDEN,
             message: Some("Not on whitelist".to_string()),
@@ -193,7 +193,7 @@ async fn list_files(
 }
 
 async fn upload_head(auth: BlossomAuth, AxumState(state): AxumState<Arc<AppState>>) -> BlossomHead {
-    check_head(auth, &state.wl, &state.settings)
+    check_head(auth, &state.wl, &state.settings).await
 }
 
 async fn upload(
@@ -212,7 +212,7 @@ async fn mirror(
     if !check_method(&auth.event, "upload") {
         return BlossomResponse::error("Invalid request method tag");
     }
-    if let Some(e) = check_whitelist(&auth, &state.wl) {
+    if let Some(e) = check_whitelist(&auth, &state.wl).await {
         return e;
     }
 
@@ -280,7 +280,7 @@ async fn mirror(
 
 #[cfg(feature = "media-compression")]
 async fn head_media(auth: BlossomAuth, AxumState(state): AxumState<Arc<AppState>>) -> BlossomHead {
-    check_head(auth, &state.wl, &state.settings)
+    check_head(auth, &state.wl, &state.settings).await
 }
 
 #[cfg(feature = "media-compression")]
@@ -292,7 +292,11 @@ async fn upload_media(
     process_upload("media", true, auth, state, body).await
 }
 
-fn check_head(auth: BlossomAuth, whitelist: &Whitelist, settings: &Settings) -> BlossomHead {
+async fn check_head(
+    auth: BlossomAuth,
+    whitelist: &Whitelist,
+    settings: &Settings,
+) -> BlossomHead {
     if !check_method(&auth.event, "upload") {
         return BlossomHead {
             msg: Some("Invalid auth method tag"),
@@ -324,7 +328,7 @@ fn check_head(auth: BlossomAuth, whitelist: &Whitelist, settings: &Settings) -> 
     }
 
     // check whitelist
-    if !whitelist.contains_hex(&auth.event.pubkey.to_hex()) {
+    if !whitelist.is_allowed(&auth.event.pubkey.to_hex()).await {
         return BlossomHead {
             msg: Some("Not on whitelist"),
         };
@@ -365,7 +369,7 @@ async fn process_upload(
     }
 
     // check whitelist
-    if let Some(e) = check_whitelist(&auth, &state.wl) {
+    if let Some(e) = check_whitelist(&auth, &state.wl).await {
         return e;
     }
 
@@ -551,7 +555,7 @@ async fn report_file(
     }
 
     // Check whitelist
-    if let Some(e) = check_whitelist(&auth, &state.wl) {
+    if let Some(e) = check_whitelist(&auth, &state.wl).await {
         return e;
     }
 

--- a/src/routes/nip96.rs
+++ b/src/routes/nip96.rs
@@ -290,7 +290,7 @@ async fn upload(
     }
 
     // check whitelist
-    if !state.wl.contains_hex(&auth.event.pubkey.to_hex()) {
+    if !state.wl.is_allowed(&auth.event.pubkey.to_hex()).await {
         return Nip96Response::Forbidden(Json(Nip96UploadResult::error("Not on whitelist")));
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,7 +1,88 @@
 #[cfg(feature = "payments")]
 use crate::payments::{Currency, PaymentAmount, PaymentInterval, PaymentUnit};
-use serde::{Deserialize, Serialize};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt;
 use std::path::PathBuf;
+
+/// How the server determines which pubkeys are allowed to upload.
+///
+/// Configured via the `whitelist` key in `config.yaml`.
+/// When the key is absent the server is open to everyone.
+///
+/// ```yaml
+/// # Database-backed list managed via the admin UI
+/// whitelist: true
+///
+/// # Static inline list of hex pubkeys
+/// whitelist:
+///   - "aabbcc..."
+///   - "ddeeff..."
+///
+/// # Hot-reloaded file (one hex pubkey per line, # comments ignored)
+/// whitelist: "/etc/route96/whitelist.txt"
+/// ```
+#[derive(Debug, Clone, Serialize)]
+pub enum WhitelistMode {
+    /// Pubkeys are managed at runtime via the admin UI and stored in the database.
+    Database,
+    /// A static list of hex pubkeys embedded directly in the config.
+    Static(Vec<String>),
+    /// Path to a plain-text file of hex pubkeys (one per line).
+    /// The server watches this file and hot-reloads it on change.
+    File(PathBuf),
+}
+
+impl<'de> Deserialize<'de> for WhitelistMode {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct WhitelistModeVisitor;
+
+        impl<'de> Visitor<'de> for WhitelistModeVisitor {
+            type Value = WhitelistMode;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    f,
+                    "true (database mode), a string path, or a list of hex pubkeys"
+                )
+            }
+
+            /// `whitelist: true` → Database mode
+            fn visit_bool<E: de::Error>(self, v: bool) -> Result<WhitelistMode, E> {
+                if v {
+                    Ok(WhitelistMode::Database)
+                } else {
+                    Err(E::custom(
+                        "whitelist: false is not valid; omit the key to disable",
+                    ))
+                }
+            }
+
+            /// `whitelist: "/path/to/file"` → File mode
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<WhitelistMode, E> {
+                Ok(WhitelistMode::File(PathBuf::from(v)))
+            }
+
+            fn visit_string<E: de::Error>(self, v: String) -> Result<WhitelistMode, E> {
+                Ok(WhitelistMode::File(PathBuf::from(v)))
+            }
+
+            /// `whitelist: ["aabb...", ...]` → Static mode
+            fn visit_seq<A: de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<WhitelistMode, A::Error> {
+                let mut pubkeys = Vec::new();
+                while let Some(s) = seq.next_element::<String>()? {
+                    pubkeys.push(s);
+                }
+                Ok(WhitelistMode::Static(pubkeys))
+            }
+        }
+
+        deserializer.deserialize_any(WhitelistModeVisitor)
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Settings {
@@ -20,12 +101,8 @@ pub struct Settings {
     /// Public facing url
     pub public_url: String,
 
-    /// Whitelisted pubkeys
-    pub whitelist: Option<Vec<String>>,
-
-    /// Path to a file containing whitelisted pubkeys (one hex key per line).
-    /// When set, the server will monitor this file and reload it if it changes.
-    pub whitelist_file: Option<PathBuf>,
+    /// Whitelist mode. Omit to allow all users to upload.
+    pub whitelist: Option<WhitelistMode>,
 
     /// Directory where HuggingFace models are cached / loaded from.
     /// Defaults to `<storage_dir>/models` when not set.
@@ -123,4 +200,38 @@ pub struct LndConfig {
     pub endpoint: String,
     pub tls: PathBuf,
     pub macaroon: PathBuf,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn whitelist_mode_deserialize_database() {
+        let mode: WhitelistMode = serde_json::from_str("true").unwrap();
+        assert!(matches!(mode, WhitelistMode::Database));
+    }
+
+    #[test]
+    fn whitelist_mode_deserialize_false_is_error() {
+        assert!(serde_json::from_str::<WhitelistMode>("false").is_err());
+    }
+
+    #[test]
+    fn whitelist_mode_deserialize_file() {
+        let mode: WhitelistMode = serde_json::from_str(r#""/etc/whitelist.txt""#).unwrap();
+        assert!(matches!(mode, WhitelistMode::File(p) if p == PathBuf::from("/etc/whitelist.txt")));
+    }
+
+    #[test]
+    fn whitelist_mode_deserialize_static_list() {
+        let mode: WhitelistMode = serde_json::from_str(r#"["aabbcc","ddeeff"]"#).unwrap();
+        assert!(matches!(mode, WhitelistMode::Static(ref v) if v == &["aabbcc", "ddeeff"]));
+    }
+
+    #[test]
+    fn whitelist_mode_deserialize_empty_list() {
+        let mode: WhitelistMode = serde_json::from_str("[]").unwrap();
+        assert!(matches!(mode, WhitelistMode::Static(ref v) if v.is_empty()));
+    }
 }

--- a/src/whitelist.rs
+++ b/src/whitelist.rs
@@ -1,60 +1,115 @@
+use crate::db::Database;
+use crate::settings::WhitelistMode;
 use log::{error, info, warn};
 use notify::{Config as NotifyConfig, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use std::collections::HashSet;
 use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::{Instant, SystemTime};
+use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio::time::{Duration, sleep};
 use tokio_util::sync::CancellationToken;
 
-#[derive(Clone, Default)]
+/// Runtime whitelist derived from [`WhitelistMode`].
+///
+/// Cloning is cheap — all state lives behind `Arc`.
+#[derive(Clone)]
 pub struct Whitelist {
-    list: Arc<RwLock<Option<HashSet<String>>>>,
+    inner: Arc<WhitelistInner>,
+}
+
+enum WhitelistInner {
+    /// Server is open; every pubkey is allowed.
+    Open,
+    /// Static in-memory set loaded from config or a hot-reloaded file.
+    InMemory(RwLock<HashSet<String>>),
+    /// Entries live in the database, managed via the admin UI.
+    Database(Database),
+}
+
+// Manual Default so callers can construct an open whitelist with `Whitelist::default()`.
+impl Default for Whitelist {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(WhitelistInner::Open),
+        }
+    }
 }
 
 impl Whitelist {
-    pub fn new(initial: Option<Vec<String>>) -> Self {
-        let set = initial.map(|v| v.into_iter().collect::<HashSet<_>>());
-        Self {
-            list: Arc::new(RwLock::new(set)),
+    /// Build a [`Whitelist`] from the configured [`WhitelistMode`].
+    ///
+    /// - `None` → open server (no restrictions).
+    /// - `Database` → DB-backed; `db` must be `Some`.
+    /// - `Static(pubkeys)` → in-memory set; `db` is not used.
+    /// - `File(path)` → starts empty; call [`start_file_watcher`] to load and
+    ///   hot-reload the file. `db` is not used.
+    pub fn from_mode(mode: Option<&WhitelistMode>, db: Option<&Database>) -> Self {
+        match mode {
+            None => Self::default(),
+            Some(WhitelistMode::Database) => Self {
+                inner: Arc::new(WhitelistInner::Database(
+                    db.expect("Database whitelist mode requires a database connection").clone(),
+                )),
+            },
+            Some(WhitelistMode::Static(pubkeys)) => {
+                let set: HashSet<String> = pubkeys.iter().cloned().collect();
+                Self {
+                    inner: Arc::new(WhitelistInner::InMemory(RwLock::new(set))),
+                }
+            }
+            Some(WhitelistMode::File(_)) => {
+                // Starts empty; the file watcher will populate it.
+                Self {
+                    inner: Arc::new(WhitelistInner::InMemory(RwLock::new(HashSet::new()))),
+                }
+            }
         }
     }
 
-    pub fn contains_hex(&self, pubkey_hex: &str) -> bool {
-        let guard = self.list.read().unwrap();
-        match &*guard {
-            Some(set) => set.contains(pubkey_hex),
-            None => true,
+    /// Returns `true` if `pubkey_hex` is permitted to upload.
+    pub async fn is_allowed(&self, pubkey_hex: &str) -> bool {
+        match self.inner.as_ref() {
+            WhitelistInner::Open => true,
+            WhitelistInner::InMemory(set) => set.read().await.contains(pubkey_hex),
+            WhitelistInner::Database(db) => match db.whitelist_contains(pubkey_hex).await {
+                Ok(found) => found,
+                Err(e) => {
+                    warn!("DB whitelist check failed, failing open: {}", e);
+                    true
+                }
+            },
         }
     }
 
-    fn replace_all(&self, new_list: Option<HashSet<String>>) {
-        let mut guard = self.list.write().unwrap();
-        *guard = new_list;
+    async fn replace_all(&self, new_set: HashSet<String>) {
+        if let WhitelistInner::InMemory(lock) = self.inner.as_ref() {
+            *lock.write().await = new_set;
+        }
     }
 
+    /// Spawn a background task that loads `path` immediately and then watches
+    /// it for changes, hot-reloading on every write.
+    ///
+    /// Should only be called when the mode is [`WhitelistMode::File`].
     pub fn start_file_watcher(&self, path: PathBuf, shutdown: CancellationToken) -> JoinHandle<()> {
         let this = self.clone();
         tokio::spawn(async move {
             let mut last_modified: Option<SystemTime> = None;
             info!("Starting whitelist watcher for {}", path.display());
-            // initial load
+
+            // Initial load
             if let Ok(md) = tokio::fs::metadata(&path).await
                 && let Ok(modified) = md.modified()
                 && let Ok(contents) = tokio::fs::read_to_string(&path).await
             {
-                let set: HashSet<String> = contents
-                    .lines()
-                    .map(|l| l.trim())
-                    .filter(|l| !l.is_empty() && !l.starts_with('#'))
-                    .map(|s| s.to_string())
-                    .collect();
-                this.replace_all(Some(set));
+                this.replace_all(parse_whitelist_file(&contents)).await;
                 last_modified = Some(modified);
                 info!("Loaded whitelist from {}", path.display());
             }
-            // Event-driven watching using notify; fallback to polling if it fails
+
+            // Event-driven watching; fall back to polling if it fails.
             let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
             let mut watcher = match RecommendedWatcher::new(
                 move |res| {
@@ -66,38 +121,30 @@ impl Whitelist {
             ) {
                 Ok(w) => w,
                 Err(e) => {
-                    warn!(
-                        "Falling back to polling: failed to create file watcher: {}",
-                        e
-                    );
-                    return fallback_polling(this, path, last_modified, shutdown.clone()).await;
+                    warn!("Falling back to polling: failed to create file watcher: {}", e);
+                    return fallback_polling(this, path, last_modified, shutdown).await;
                 }
             };
+
             let target_name = match path.file_name().map(|s| s.to_os_string()) {
                 Some(n) => n,
                 None => {
                     warn!("Invalid whitelist file path: {}", path.display());
-                    return fallback_polling(this, path, last_modified, shutdown.clone()).await;
+                    return fallback_polling(this, path, last_modified, shutdown).await;
                 }
             };
-            let watch_path = path
-                .parent()
-                .map(|p| p.to_path_buf())
-                .unwrap_or(path.clone());
+            let watch_path = path.parent().map(|p| p.to_path_buf()).unwrap_or(path.clone());
 
             if let Err(e) = watcher.watch(&watch_path, RecursiveMode::NonRecursive) {
-                warn!(
-                    "Falling back to polling: failed to watch {}: {}",
-                    path.display(),
-                    e
-                );
-                return fallback_polling(this, path, last_modified, shutdown.clone()).await;
+                warn!("Falling back to polling: failed to watch {}: {}", path.display(), e);
+                return fallback_polling(this, path, last_modified, shutdown).await;
             }
+
             let mut pending_change = false;
             let mut last_evt: Option<Instant> = None;
             let mut debounce = tokio::time::interval(Duration::from_millis(300));
-            // first tick completes immediately; advance it to avoid immediate fire
-            debounce.tick().await;
+            debounce.tick().await; // first tick fires immediately; skip it
+
             loop {
                 tokio::select! {
                     _ = shutdown.cancelled() => {
@@ -107,11 +154,17 @@ impl Whitelist {
                     Some(evt) = rx.recv() => {
                         match evt {
                             Ok(event) => {
-                                // Only react to events that reference our target filename
-                                let relevant = event.paths.iter().any(|p| p.file_name().map(|n| n==target_name.as_os_str()).unwrap_or(false));
+                                let relevant = event.paths.iter().any(|p| {
+                                    p.file_name().map(|n| n == target_name.as_os_str()).unwrap_or(false)
+                                });
                                 if !relevant { continue; }
                                 match event.kind {
-                                    EventKind::Modify(_) | EventKind::Create(_) | EventKind::Remove(_) | EventKind::Access(notify::event::AccessKind::Close(notify::event::AccessMode::Write)) => {
+                                    EventKind::Modify(_)
+                                    | EventKind::Create(_)
+                                    | EventKind::Remove(_)
+                                    | EventKind::Access(notify::event::AccessKind::Close(
+                                        notify::event::AccessMode::Write,
+                                    )) => {
                                         pending_change = true;
                                         last_evt = Some(Instant::now());
                                     }
@@ -123,16 +176,12 @@ impl Whitelist {
                     }
                     _ = debounce.tick() => {
                         if pending_change {
-                            if let Some(t) = last_evt && t.elapsed() < Duration::from_millis(250) { continue; }
+                            if let Some(t) = last_evt && t.elapsed() < Duration::from_millis(250) {
+                                continue;
+                            }
                             match tokio::fs::read_to_string(&path).await {
                                 Ok(contents) => {
-                                    let set: HashSet<String> = contents
-                                        .lines()
-                                        .map(|l| l.trim())
-                                        .filter(|l| !l.is_empty() && !l.starts_with('#'))
-                                        .map(|s| s.to_string())
-                                        .collect();
-                                    this.replace_all(Some(set));
+                                    this.replace_all(parse_whitelist_file(&contents)).await;
                                     info!("Reloaded whitelist from {} (debounced)", path.display());
                                 }
                                 Err(e) => {
@@ -145,6 +194,95 @@ impl Whitelist {
                 }
             }
         })
+    }
+}
+
+pub(crate) fn parse_whitelist_file(contents: &str) -> HashSet<String> {
+    contents
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::WhitelistMode;
+
+    // ── parse_whitelist_file ────────────────────────────────────────────────
+
+    #[test]
+    fn parse_strips_comments_and_blanks() {
+        let contents = "# comment\naabbcc\n\n  ddeeff  \n# another comment\n112233\n";
+        let set = parse_whitelist_file(contents);
+        assert_eq!(set.len(), 3);
+        assert!(set.contains("aabbcc"));
+        assert!(set.contains("ddeeff"));
+        assert!(set.contains("112233"));
+    }
+
+    #[test]
+    fn parse_empty_file() {
+        assert!(parse_whitelist_file("").is_empty());
+        assert!(parse_whitelist_file("# only comments\n\n").is_empty());
+    }
+
+    // ── Whitelist::from_mode ────────────────────────────────────────────────
+
+    // Open (no mode configured) — every pubkey is allowed.
+    #[tokio::test]
+    async fn open_allows_all() {
+        // No DB needed; from_mode(None, _) ignores the db argument.
+        // We use a dummy database URL — from_mode with None never touches the DB.
+        let wl = Whitelist::default();
+        assert!(wl.is_allowed("aabbcc").await);
+        assert!(wl.is_allowed("000000").await);
+    }
+
+    // Static mode — only listed pubkeys are allowed.
+    #[tokio::test]
+    async fn static_allows_listed_pubkey() {
+        let mode = WhitelistMode::Static(vec!["aabbcc".to_string()]);
+        let wl = Whitelist::from_mode(Some(&mode), None);
+        assert!(wl.is_allowed("aabbcc").await);
+    }
+
+    #[tokio::test]
+    async fn static_denies_unlisted_pubkey() {
+        let mode = WhitelistMode::Static(vec!["aabbcc".to_string()]);
+        let wl = Whitelist::from_mode(Some(&mode), None);
+        assert!(!wl.is_allowed("ddeeff").await);
+    }
+
+    #[tokio::test]
+    async fn static_empty_list_denies_all() {
+        let mode = WhitelistMode::Static(vec![]);
+        let wl = Whitelist::from_mode(Some(&mode), None);
+        assert!(!wl.is_allowed("aabbcc").await);
+    }
+
+    // File mode — starts with an empty in-memory set (watcher not running),
+    // so every pubkey is denied until replace_all is called.
+    #[tokio::test]
+    async fn file_mode_starts_empty() {
+        let mode = WhitelistMode::File("/nonexistent".into());
+        let wl = Whitelist::from_mode(Some(&mode), None);
+        assert!(!wl.is_allowed("aabbcc").await);
+    }
+
+    // replace_all (via file mode) correctly swaps the in-memory set.
+    #[tokio::test]
+    async fn file_mode_replace_all_updates_set() {
+        let mode = WhitelistMode::File("/nonexistent".into());
+        let wl = Whitelist::from_mode(Some(&mode), None);
+        assert!(!wl.is_allowed("aabbcc").await);
+
+        let new_set: HashSet<String> = ["aabbcc".to_string()].into();
+        wl.replace_all(new_set).await;
+        assert!(wl.is_allowed("aabbcc").await);
+        assert!(!wl.is_allowed("ddeeff").await);
     }
 }
 
@@ -162,39 +300,27 @@ async fn fallback_polling(
             }
             _ = sleep(Duration::from_secs(10)) => {
                 match tokio::fs::metadata(&path).await {
-                    Ok(md) => {
-                        match md.modified() {
-                            Ok(modified) => {
-                                let changed = match last_modified {
-                                    Some(prev) => modified > prev,
-                                    None => true,
-                                };
-                                if changed {
-                                    match tokio::fs::read_to_string(&path).await {
-                                        Ok(contents) => {
-                                            let set: HashSet<String> = contents
-                                                .lines()
-                                                .map(|l| l.trim())
-                                                .filter(|l| !l.is_empty() && !l.starts_with('#'))
-                                                .map(|s| s.to_string())
-                                                .collect();
-                                            this.replace_all(Some(set));
-                                            last_modified = Some(modified);
-                                            info!("Reloaded whitelist from {}", path.display());
-                                        }
-                                        Err(e) => {
-                                            warn!("Failed to read whitelist file {}: {}", path.display(), e);
-                                        }
+                    Ok(md) => match md.modified() {
+                        Ok(modified) => {
+                            let changed = last_modified.map_or(true, |prev| modified > prev);
+                            if changed {
+                                match tokio::fs::read_to_string(&path).await {
+                                    Ok(contents) => {
+                                        this.replace_all(parse_whitelist_file(&contents)).await;
+                                        last_modified = Some(modified);
+                                        info!("Reloaded whitelist from {}", path.display());
+                                    }
+                                    Err(e) => {
+                                        warn!("Failed to read whitelist file {}: {}", path.display(), e);
                                     }
                                 }
                             }
-                            Err(e) => {
-                                warn!("Failed to get modification time for {}: {}", path.display(), e);
-                            }
                         }
-                    }
+                        Err(e) => {
+                            warn!("Failed to get modification time for {}: {}", path.display(), e);
+                        }
+                    },
                     Err(e) => {
-                        // If file doesn't exist or can't stat, keep previous list
                         warn!("Failed to stat whitelist file {}: {}", path.display(), e);
                     }
                 }

--- a/ui_src/src/upload/admin.ts
+++ b/ui_src/src/upload/admin.ts
@@ -47,6 +47,11 @@ export interface Report {
   reviewed: boolean;
 }
 
+export interface WhitelistEntry {
+  pubkey: string;
+  created: string;
+}
+
 export interface PaymentInfo {
   unit: string;
   interval: {
@@ -191,6 +196,34 @@ export class Route96 {
       await this.#handleResponse<AdminResponse<Array<SimilarFile>>>(rsp);
     if (!data.data) throw new Error(data.message || "Find similar failed");
     return data.data;
+  }
+
+  async listWhitelist() {
+    const rsp = await this.#req("admin/whitelist", "GET");
+    const data =
+      await this.#handleResponse<AdminResponse<WhitelistEntry[]>>(rsp);
+    if (!data.data) throw new Error(data.message || "List whitelist failed");
+    return data.data;
+  }
+
+  async addToWhitelist(pubkey: string) {
+    const rsp = await this.#req(
+      "admin/whitelist",
+      "POST",
+      JSON.stringify({ pubkey }),
+    );
+    const data = await this.#handleResponse<AdminResponse<void>>(rsp);
+    return data;
+  }
+
+  async removeFromWhitelist(pubkey: string) {
+    const rsp = await this.#req(
+      "admin/whitelist",
+      "DELETE",
+      JSON.stringify({ pubkey }),
+    );
+    const data = await this.#handleResponse<AdminResponse<void>>(rsp);
+    return data;
   }
 
   async getPaymentInfo() {

--- a/ui_src/src/views/admin.tsx
+++ b/ui_src/src/views/admin.tsx
@@ -11,11 +11,12 @@ import {
   Route96,
   Report,
   SimilarFile,
+  WhitelistEntry,
 } from "../upload/admin";
 import { Blossom } from "../upload/blossom";
 import { FormatBytes } from "../const";
 
-type Tab = "files" | "reports" | "review";
+type Tab = "files" | "reports" | "review" | "whitelist";
 
 type AdminFileList = {
   count: number;
@@ -45,6 +46,11 @@ export default function Admin() {
   // Review tab
   const [pendingReview, setPendingReview] = useState<AdminFileList>();
   const [pendingReviewPage, setPendingReviewPage] = useState(0);
+
+  // Whitelist tab
+  const [whitelist, setWhitelist] = useState<WhitelistEntry[]>();
+  const [whitelistInput, setWhitelistInput] = useState("");
+  const [whitelistLoading, setWhitelistLoading] = useState(false);
 
   // Similar images modal
   const [similarFiles, setSimilarFiles] = useState<SimilarFile[]>();
@@ -114,6 +120,59 @@ export default function Admin() {
     },
     [pub, url],
   );
+
+  const listWhitelist = useCallback(async () => {
+    if (!pub) return;
+    try {
+      setError(undefined);
+      const route96 = new Route96(url, pub);
+      const result = await route96.listWhitelist();
+      setWhitelist(result);
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? e.message || "List whitelist failed"
+          : "List whitelist failed",
+      );
+    }
+  }, [pub, url]);
+
+  async function addToWhitelist() {
+    if (!pub || !whitelistInput.trim()) return;
+    const pubkey = whitelistInput.trim().toLowerCase();
+    setWhitelistLoading(true);
+    try {
+      setError(undefined);
+      const route96 = new Route96(url, pub);
+      await route96.addToWhitelist(pubkey);
+      setWhitelistInput("");
+      await listWhitelist();
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? e.message || "Add to whitelist failed"
+          : "Add to whitelist failed",
+      );
+    } finally {
+      setWhitelistLoading(false);
+    }
+  }
+
+  async function removeFromWhitelist(pubkey: string) {
+    if (!pub) return;
+    try {
+      setError(undefined);
+      const route96 = new Route96(url, pub);
+      await route96.removeFromWhitelist(pubkey);
+      await listWhitelist();
+    } catch (e) {
+      setError(
+        e instanceof Error
+          ? e.message || "Remove from whitelist failed"
+          : "Remove from whitelist failed",
+      );
+    }
+  }
 
   async function acknowledgeReport(reportId: number) {
     if (!pub) return;
@@ -287,6 +346,12 @@ export default function Admin() {
     }
   }, [tab, pendingReviewPage, pub, self?.is_admin, listPendingReview]);
 
+  useEffect(() => {
+    if (pub && self?.is_admin && tab === "whitelist") {
+      listWhitelist();
+    }
+  }, [tab, pub, self?.is_admin, listWhitelist]);
+
   if (loading) {
     return (
       <div className="flex justify-center items-center h-48">
@@ -316,6 +381,7 @@ export default function Admin() {
     { id: "files", label: "Files" },
     { id: "reports", label: "Reports" },
     { id: "review", label: "Review" },
+    { id: "whitelist", label: "Whitelist" },
   ];
 
   return (
@@ -450,6 +516,68 @@ export default function Admin() {
             </>
           )}
         </>
+      )}
+
+      {tab === "whitelist" && (
+        <div className="space-y-4">
+          <p className="text-xs text-neutral-500">
+            Pubkeys listed here are allowed to upload files. When this list is
+            empty and no static whitelist is configured, the server is open to
+            everyone.
+          </p>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              placeholder="Add pubkey (64-char hex)..."
+              className="flex-1 h-7 rounded-sm border border-neutral-800 bg-neutral-950 px-2 text-xs text-neutral-300 placeholder-neutral-600 font-mono"
+              value={whitelistInput}
+              onChange={(e) => setWhitelistInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") addToWhitelist();
+              }}
+            />
+            <button
+              onClick={addToWhitelist}
+              disabled={whitelistLoading || !whitelistInput.trim()}
+              className="bg-neutral-800 hover:bg-neutral-700 disabled:opacity-40 text-white px-3 py-1 rounded-sm text-xs"
+            >
+              Add
+            </button>
+          </div>
+
+          {whitelist && whitelist.length === 0 && (
+            <div className="text-xs text-neutral-500 text-center py-6">
+              No entries — server is open to all users.
+            </div>
+          )}
+
+          {whitelist && whitelist.length > 0 && (
+            <div className="space-y-1">
+              {whitelist.map((entry) => (
+                <div
+                  key={entry.pubkey}
+                  className="flex items-center justify-between bg-neutral-900 border border-neutral-800 rounded-sm px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <div className="font-mono text-xs text-neutral-300 truncate">
+                      {entry.pubkey}
+                    </div>
+                    <div className="text-xs text-neutral-600 mt-0.5">
+                      Added {new Date(entry.created).toLocaleString()}
+                    </div>
+                  </div>
+                  <button
+                    onClick={() => removeFromWhitelist(entry.pubkey)}
+                    className="ml-3 shrink-0 bg-neutral-800 hover:bg-red-900 text-neutral-400 hover:text-red-200 px-2 py-0.5 rounded-sm text-xs transition-colors"
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       )}
 
       {(similarFiles || similarLoading) && similarSource && (


### PR DESCRIPTION
## Summary

Implements #60 — an in-app whitelist backed by the database, manageable via the admin panel.

- **Migration** (`20260311100000_whitelist.sql`): new `whitelist` table with `pubkey` (primary key) and `created` columns
- **`Whitelist` struct** (`src/whitelist.rs`): attach a `Database` reference; new async `is_allowed()` method that checks config/file entries **and** DB entries — open server when neither source has entries
- **DB methods** (`src/db.rs`): `whitelist_add`, `whitelist_remove`, `whitelist_list`, `whitelist_contains`, `whitelist_is_enabled`
- **Admin API** (`src/routes/admin.rs`): `GET/POST/DELETE /admin/whitelist` endpoints (admin auth required)
- **Blossom/NIP-96 enforcement** updated to use the new async `is_allowed()` so DB entries are respected at upload time
- **TypeScript client** (`ui_src/src/upload/admin.ts`): `listWhitelist`, `addToWhitelist`, `removeFromWhitelist`
- **Admin UI** (`ui_src/src/views/admin.tsx`): new **Whitelist** tab with add/remove pubkey management and a hint that an empty list means the server is open to everyone

Closes #60