### PR TITLE
Security, bug, and performance audit fixes

### DIFF
--- a/src/auth/blossom.rs
+++ b/src/auth/blossom.rs
@@ -40,6 +40,78 @@ impl IntoResponse for BlossomRejection {
 }
 
 impl BlossomAuth {
+    /// Validate that a URL is safe for the server to fetch (mirror requests).
+    ///
+    /// Rejects non-http(s) schemes and any host that resolves to a
+    /// loopback, private, link-local or otherwise non-public address, to
+    /// prevent SSRF against internal services / cloud metadata endpoints.
+    pub async fn validate_mirror_url(url: &url::Url) -> Result<(), BlossomRejection> {
+        use std::net::IpAddr;
+
+        fn ip_is_public(ip: &IpAddr) -> bool {
+            match ip {
+                IpAddr::V4(v4) => {
+                    !(v4.is_private()
+                        || v4.is_loopback()
+                        || v4.is_link_local()
+                        || v4.is_broadcast()
+                        || v4.is_documentation()
+                        || v4.is_unspecified()
+                        // CGNAT / carrier-grade NAT 100.64.0.0/10
+                        || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64)
+                        // 0.0.0.0/8, 192.0.0.0/24, 198.18.0.0/15 benchmarking,
+                        // 240.0.0.0/4 reserved
+                        || v4.octets()[0] == 0
+                        || (v4.octets()[0] == 192 && v4.octets()[1] == 0 && v4.octets()[2] == 0)
+                        || (v4.octets()[0] == 198 && (v4.octets()[1] & 0xFE) == 18)
+                        || v4.octets()[0] >= 240)
+                }
+                IpAddr::V6(v6) => {
+                    !(v6.is_loopback()
+                        || v6.is_unspecified()
+                        || v6.is_unique_local()
+                        || v6.is_unicast_link_local()
+                        // IPv4-mapped IPv6 — re-check the embedded v4 address
+                        || v6
+                            .to_ipv4_mapped()
+                            .is_some_and(|v4| !ip_is_public(&IpAddr::V4(v4))))
+                }
+            }
+        }
+
+        let reject = || BlossomRejection {
+            status: StatusCode::BAD_REQUEST,
+            reason: "URL is not fetchable by this server",
+        };
+
+        if url.scheme() != "http" && url.scheme() != "https" {
+            return Err(reject());
+        }
+
+        let host = url.host_str().ok_or_else(reject)?;
+        let port = url.port_or_known_default().unwrap_or(80);
+
+        // Literal IP host — check directly.
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            if !ip_is_public(&ip) {
+                return Err(reject());
+            }
+            return Ok(());
+        }
+
+        // DNS name — resolve and require at least one public address; reject
+        // if ANY resolved address is non-public (DNS rebinding safety).
+        let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host((host, port))
+            .await
+            .map_err(|_| reject())?
+            .collect();
+        if addrs.is_empty() || addrs.iter().any(|a| !ip_is_public(&a.ip())) {
+            return Err(reject());
+        }
+
+        Ok(())
+    }
+
     /// Get all x tags from the authorization event
     pub fn x_tags(&self) -> Vec<String> {
         self.event.tags.iter().filter_map(|t| {
@@ -146,7 +218,15 @@ where
                 None
             }
         }) {
-            let u_exp: Timestamp = expiration.parse().unwrap();
+            let u_exp: Timestamp = match expiration.parse() {
+                Ok(t) => t,
+                Err(_) => {
+                    return Err(BlossomRejection {
+                        status: StatusCode::BAD_REQUEST,
+                        reason: "Invalid expiration tag",
+                    });
+                }
+            };
             if u_exp <= Timestamp::now() {
                 return Err(BlossomRejection { status: StatusCode::BAD_REQUEST, reason: "Expiration invalid" });
             }

--- a/src/auth/nip98.rs
+++ b/src/auth/nip98.rs
@@ -139,6 +139,11 @@ where
             });
         }
 
+        // NOTE: NIP-98's optional `payload` tag (body hash) cannot be
+        // verified here because `FromRequestParts` has no access to the
+        // request body. Replay resistance relies on the short 10-minute
+        // expiration window enforced above.
+
         event
             .verify()
             .map_err(|_| Nip98Rejection { status: StatusCode::UNAUTHORIZED, reason: "Event signature invalid" })?;

--- a/src/db.rs
+++ b/src/db.rs
@@ -252,6 +252,26 @@ impl Database {
         Ok(())
     }
 
+    /// Create the first admin user atomically.
+    ///
+    /// The `is_admin` flag is only set if no admin exists yet, so concurrent
+    /// setup requests can't both be promoted. Returns the user id and whether
+    /// the caller was granted admin.
+    pub async fn upsert_first_admin(&self, pubkey: &Vec<u8>) -> Result<(u64, bool), Error> {
+        sqlx::query(
+            "insert into users(pubkey, is_admin) values(?, not exists(select 1 from (select id from users where is_admin = 1 limit 1) a)) \
+             on duplicate key update id = last_insert_id(id)",
+        )
+        .bind(pubkey)
+        .execute(&self.pool)
+        .await?;
+        let row = sqlx::query("select id, is_admin from users where pubkey = ?")
+            .bind(pubkey)
+            .fetch_one(&self.pool)
+            .await?;
+        Ok((row.try_get(0)?, row.try_get(1)?))
+    }
+
     pub async fn get_user(&self, pubkey: &Vec<u8>) -> Result<User, Error> {
         sqlx::query_as("select * from users where pubkey = ?")
             .bind(pubkey)
@@ -387,6 +407,28 @@ impl Database {
         Ok(result)
     }
 
+    /// Fetch multiple files by id in a single query, keyed by file id.
+    pub async fn get_files_batch(
+        &self,
+        file_ids: &[&[u8]],
+    ) -> Result<std::collections::HashMap<Vec<u8>, FileUpload>, Error> {
+        use std::collections::HashMap;
+        if file_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut qb = QueryBuilder::new("select * from uploads where id in (");
+        let mut sep = qb.separated(", ");
+        for id in file_ids {
+            sep.push_bind(*id);
+        }
+        sep.push_unseparated(")");
+        #[allow(unused_mut)]
+        let mut files: Vec<FileUpload> = qb.build_query_as().fetch_all(&self.pool).await?;
+        #[cfg(feature = "labels")]
+        self.populate_labels_vec(&mut files).await?;
+        Ok(files.into_iter().map(|f| (f.id.clone(), f)).collect())
+    }
+
     pub async fn get_file_owners(&self, file: &Vec<u8>) -> Result<Vec<User>, Error> {
         sqlx::query_as(
             "select users.* from users, user_uploads \
@@ -515,6 +557,16 @@ impl Database {
             .bind(file)
             .execute(&self.pool)
             .await?;
+        // Clean up auxiliary rows that reference the file (FK cascades cover
+        // reports and phash, but be explicit for tables without cascades).
+        for q in [
+            "delete from file_stats where file = ?",
+            "delete from upload_labels where file = ?",
+        ] {
+            if let Err(e) = sqlx::query(q).bind(file).execute(&self.pool).await {
+                log::warn!("Failed to clean up file references: {}", e);
+            }
+        }
         Ok(())
     }
 
@@ -585,7 +637,7 @@ impl Database {
     }
 
     /// List files with cursor-based pagination (BUD-12).
-    /// 
+    ///
     /// Returns files sorted by created date descending, starting after the cursor.
     /// The cursor should be the sha256 hash of the last file from the previous page.
     pub async fn list_files_cursor(
@@ -594,28 +646,43 @@ impl Database {
         cursor: Option<&str>,
         limit: u32,
     ) -> Result<Vec<FileUpload>, Error> {
-        let query = match cursor {
+        let mut results: Vec<FileUpload> = match cursor {
             Some(cursor_hash) => {
-                // Decode cursor hash for comparison
-                if let Ok(cursor_bytes) = hex::decode(cursor_hash) {
-                    sqlx::query_as(
-                        "select uploads.* from uploads, users, user_uploads \
-                        where users.pubkey = ? \
-                        and users.id = user_uploads.user_id \
-                        and user_uploads.file = uploads.id \
-                        and uploads.banned = false \
-                        and (uploads.created, uploads.id) < (?, ?) \
-                        order by uploads.created desc, uploads.id desc \
-                        limit ?",
-                    )
-                    .bind(pubkey)
-                    .bind(cursor_bytes.clone())
-                    .bind(cursor_bytes)
-                    .bind(limit)
-                } else {
+                let cursor_bytes = match hex::decode(cursor_hash) {
+                    Ok(b) if b.len() == 32 => b,
                     // Invalid cursor, return empty result
-                    return Ok(vec![]);
-                }
+                    _ => return Ok(vec![]),
+                };
+                // Look up the cursor row so we can keyset-paginate on
+                // (created, id) — comparing created directly against the raw
+                // hash bytes would be meaningless.
+                let cursor_row: Option<(DateTime<Utc>,)> = sqlx::query_as(
+                    "select created from uploads where id = ?",
+                )
+                .bind(&cursor_bytes)
+                .fetch_optional(&self.pool)
+                .await?;
+                let (cursor_created,) = match cursor_row {
+                    Some(r) => r,
+                    None => return Ok(vec![]),
+                };
+                sqlx::query_as(
+                    "select uploads.* from uploads, users, user_uploads \
+                    where users.pubkey = ? \
+                    and users.id = user_uploads.user_id \
+                    and user_uploads.file = uploads.id \
+                    and uploads.banned = false \
+                    and (uploads.created < ? or (uploads.created = ? and uploads.id < ?)) \
+                    order by uploads.created desc, uploads.id desc \
+                    limit ?",
+                )
+                .bind(pubkey)
+                .bind(cursor_created)
+                .bind(cursor_created)
+                .bind(&cursor_bytes)
+                .bind(limit)
+                .fetch_all(&self.pool)
+                .await?
             }
             None => {
                 sqlx::query_as(
@@ -624,15 +691,15 @@ impl Database {
                     and users.id = user_uploads.user_id \
                     and user_uploads.file = uploads.id \
                     and uploads.banned = false \
-                    order by uploads.created desc \
+                    order by uploads.created desc, uploads.id desc \
                     limit ?",
                 )
                 .bind(pubkey)
                 .bind(limit)
+                .fetch_all(&self.pool)
+                .await?
             }
         };
-
-        let mut results: Vec<FileUpload> = query.fetch_all(&self.pool).await?;
 
         #[cfg(feature = "labels")]
         self.populate_labels_vec(&mut results).await?;

--- a/src/file_stats.rs
+++ b/src/file_stats.rs
@@ -131,6 +131,9 @@ impl FileStatsTracker {
                     hex::encode(&snap.file_id),
                     e
                 );
+                // Re-record the delta so it isn't lost — it will be retried
+                // on the next flush.
+                self.record(&snap.file_id, snap.egress_bytes, snap.last_accessed);
             }
         }
     }

--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -125,12 +125,27 @@ impl FileStore {
         let mut res = if compress && crate::can_compress(mime_type) {
             #[cfg(feature = "media-compression")]
             {
-                let res = match self.compress_file(&temp_file, mime_type).await {
+                // FFmpeg transcode is blocking CPU-bound work; run it off the
+                // async executor.
+                let temp_clone = temp_file.clone();
+                let mime_owned = mime_type.to_string();
+                let compress_res = {
+                    let fs_self = self.clone();
+                    tokio::task::spawn_blocking(move || {
+                        fs_self.compress_file_sync(&temp_clone, &mime_owned)
+                    })
+                    .await
+                };
+                let res = match compress_res {
                     Err(e) => {
+                        tokio::fs::remove_file(&temp_file).await?;
+                        return Err(Error::msg(format!("Compression task failed: {}", e)));
+                    }
+                    Ok(Err(e)) => {
                         tokio::fs::remove_file(&temp_file).await?;
                         return Err(e);
                     }
-                    Ok(res) => res,
+                    Ok(Ok(res)) => res,
                 };
                 tokio::fs::remove_file(temp_file).await?;
                 res
@@ -143,7 +158,12 @@ impl FileStore {
             let (width, height, mime_type, duration, bitrate) = {
                 #[cfg(feature = "media-compression")]
                 {
-                    let probe = probe_file(&temp_file).ok();
+                    // Probe is blocking FFmpeg work; run off the executor.
+                    let probe_path = temp_file.clone();
+                    let probe = tokio::task::spawn_blocking(move || probe_file(&probe_path).ok())
+                        .await
+                        .ok()
+                        .flatten();
                     let v_stream = probe.as_ref().and_then(|p| p.best_video());
                     let mime = Self::hack_mime_type(mime_type, &probe, &v_stream, &temp_file);
                     (
@@ -310,16 +330,11 @@ impl FileStore {
     }
 
     #[cfg(feature = "media-compression")]
-    async fn compress_file(&self, input: &Path, mime_type: &str) -> Result<NewFileResult> {
+    /// Synchronous compression — call inside `spawn_blocking`.
+    fn compress_file_sync(&self, input: &Path, mime_type: &str) -> Result<NewFileResult> {
         let compressed_result = compress_file(input, mime_type, &self.temp_dir())?;
-
-        let hash = FileStore::hash_file(&compressed_result.result).await?;
-
-        let n = File::open(&compressed_result.result)
-            .await?
-            .metadata()
-            .await?
-            .len();
+        let hash = Self::hash_file_sync(&compressed_result.result)?;
+        let n = std::fs::metadata(&compressed_result.result)?.len();
         Ok(NewFileResult {
             path: compressed_result.result,
             id: hash,
@@ -334,6 +349,22 @@ impl FileStore {
             #[cfg(feature = "labels")]
             labels: vec![],
         })
+    }
+
+    #[cfg(feature = "media-compression")]
+    fn hash_file_sync(p: &Path) -> Result<Vec<u8>, Error> {
+        use std::io::Read;
+        let mut file = std::fs::File::open(p)?;
+        let mut hasher = Sha256::new();
+        let mut buf = [0; 8192];
+        loop {
+            let n = file.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+        }
+        Ok(hasher.finalize().to_vec())
     }
 
     async fn store_hash_temp_file<S>(&self, mut stream: S) -> Result<(PathBuf, u64, Vec<u8>)>

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -548,13 +548,14 @@ async fn post_setup(
         return AdminResponse::error("public_url must start with http:// or https://");
     }
 
-    // Create the submitting user and promote them to admin.
+    // Create the submitting user and promote them to admin atomically — the
+    // is_admin flag is only set if no admin exists yet, so a concurrent
+    // request can't also win the race.
     let pubkey_vec = auth.event.pubkey.to_bytes().to_vec();
-    if let Err(e) = state.db.upsert_user(&pubkey_vec).await {
-        return AdminResponse::error(&format!("Failed to create user: {}", e));
-    }
-    if let Err(e) = state.db.promote_to_admin(&pubkey_vec).await {
-        return AdminResponse::error(&format!("Failed to promote user to admin: {}", e));
+    match state.db.upsert_first_admin(&pubkey_vec).await {
+        Ok((_, true)) => {}
+        Ok((_, false)) => return AdminResponse::error("Server is already configured"),
+        Err(e) => return AdminResponse::error(&format!("Failed to create user: {}", e)),
     }
 
     if let Err(e) = state.db.config_set("public_url", public_url).await {
@@ -1167,11 +1168,19 @@ async fn admin_similar_files(
         Err(e) => return AdminResponse::error(&format!("DB error: {}", e)),
     };
 
+    // Fetch all candidate uploads in one query instead of N+1 lookups.
+    let candidate_ids: Vec<&[u8]> = candidates.iter().map(|(id, _)| id.as_slice()).collect();
+    let uploads = match state.db.get_files_batch(&candidate_ids).await {
+        Ok(u) => u,
+        Err(e) => return AdminResponse::error(&format!("DB error: {}", e)),
+    };
+
+    let settings = state.settings().await;
     let mut results = Vec::with_capacity(candidates.len());
     for (file_id_bytes, dist) in candidates {
-        if let Ok(Some(upload)) = state.db.get_file(&file_id_bytes).await {
+        if let Some(upload) = uploads.get(&file_id_bytes) {
             results.push(SimilarFile {
-                inner: Nip94Event::from_upload(&state.settings().await, &upload),
+                inner: Nip94Event::from_upload(&settings, upload),
                 distance: dist,
             });
         }

--- a/src/routes/blossom.rs
+++ b/src/routes/blossom.rs
@@ -462,12 +462,28 @@ async fn mirror(
         Err(e) => return BlossomResponse::bad_request(format!("Invalid URL: {}", e)),
     };
 
+    // SSRF protection: only allow fetching public http(s) URLs.
+    if BlossomAuth::validate_mirror_url(&url).await.is_err() {
+        return BlossomResponse::bad_request("URL is not fetchable by this server");
+    }
+
     let hash = url
         .path_segments()
         .and_then(|mut c| c.next_back())
         .and_then(|s| s.split(".").next());
 
-    let client = Client::builder().build().unwrap();
+    let client = match Client::builder()
+        .timeout(std::time::Duration::from_secs(120))
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            error!("Failed to build HTTP client: {}", e);
+            return BlossomResponse::service_unavailable("Mirror fetch failed");
+        }
+    };
 
     let req_builder = client.get(url.clone()).header(
         "user-agent",
@@ -921,7 +937,14 @@ where
             });
         }
         Ok(FileSystemResult::AlreadyExists(i)) => match state.db.get_file(&i).await {
-            Ok(Some(f)) => f,
+            Ok(Some(f)) if !f.banned => f,
+            Ok(Some(_)) => {
+                return BlossomResponse::Generic(BlossomGenericResponse {
+                    message: Some("File is not allowed on this server".to_string()),
+                    status: StatusCode::FORBIDDEN,
+                    payment_headers: None,
+                });
+            }
             _ => return BlossomResponse::not_found("File not found"),
         },
         Err(e) => {
@@ -937,10 +960,12 @@ where
         }
     };
 
-    // Post-upload quota check if we didn't have size information before upload (only if payments are configured)
+    // Post-upload quota check, using the actual stored size. The declared
+    // size is only a hint and is never trusted for quota enforcement.
     #[cfg(feature = "payments")]
-    if size == 0 {
-        if let Some(payment_config) = &settings.payments {
+    {
+        let _ = size;
+        if is_new_file && let Some(payment_config) = &settings.payments {
             let free_quota = payment_config.free_quota_bytes.unwrap_or(104857600); // Default to 100MB
 
             match state
@@ -1006,6 +1031,20 @@ async fn report_file(
 
     if file_hashes.is_empty() {
         return BlossomResponse::bad_request("Missing file hash in x tag");
+    }
+
+    // Cap the number of files per report to bound request cost.
+    if file_hashes.len() > 100 {
+        return BlossomResponse::bad_request("Too many files in one report (max 100)");
+    }
+
+    // Only consider 32-byte hashes (SHA-256); shorter values are invalid.
+    let file_hashes: Vec<Vec<u8>> = file_hashes
+        .into_iter()
+        .filter(|h| h.len() == 32)
+        .collect();
+    if file_hashes.is_empty() {
+        return BlossomResponse::bad_request("No valid file hashes in x tags");
     }
 
     // Get or create the reporter user from the report event pubkey

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -31,10 +31,10 @@ use serde::Serialize;
 use std::env::temp_dir;
 use std::io::SeekFrom;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncSeekExt};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tokio_util::io::ReaderStream;
 
 mod admin;
@@ -99,6 +99,12 @@ impl AppState {
         }
     }
 }
+
+/// Serialize thumbnail generation per file so concurrent requests for the
+/// same hash don't race writing the same temp file.
+#[cfg(feature = "media-compression")]
+static THUMB_LOCKS: LazyLock<Mutex<std::collections::HashMap<String, Arc<Mutex<()>>>>> =
+    LazyLock::new(|| Mutex::new(std::collections::HashMap::new()));
 
 pub struct FilePayload {
     pub file: File,
@@ -336,12 +342,24 @@ fn set_file_headers(response: &mut Response, info: &FileUpload) {
     response
         .headers_mut()
         .insert(header::ACCEPT_RANGES, "bytes".parse().unwrap());
-    if let Some(name) = &info.name
-        && let Ok(disposition) = format!("inline; filename=\"{}\"", name).parse()
-    {
-        response
-            .headers_mut()
-            .insert(header::CONTENT_DISPOSITION, disposition);
+    if let Some(name) = &info.name {
+        // Sanitize the filename: strip characters that could break out of the
+        // quoted-string (", \, CR, LF and other control chars).
+        let safe: String = name
+            .chars()
+            .map(|c| {
+                if c.is_ascii() && !c.is_ascii_control() && c != '"' && c != '\\' {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        if let Ok(disposition) = format!("inline; filename=\"{}\"", safe).parse() {
+            response
+                .headers_mut()
+                .insert(header::CONTENT_DISPOSITION, disposition);
+        }
     }
 }
 
@@ -365,10 +383,7 @@ async fn delete_file(
     if id.len() != 32 {
         return Err(Error::msg("Invalid file id"));
     }
-    if let Ok(Some(info)) = db.get_file(&id).await {
-        if info.banned {
-            return Err(Error::msg("File is banned and cannot be deleted"));
-        }
+    if let Ok(Some(_info)) = db.get_file(&id).await {
         let pubkey_vec = auth.pubkey.to_bytes().to_vec();
         let auth_user = db.get_user(&pubkey_vec).await?;
         let owners = db.get_file_owners(&id).await?;
@@ -441,21 +456,16 @@ fn get_range_from_header(range_header: &str, file_size: u64) -> Option<(u64, u64
     };
 
     let end = match single_range.end {
-        EndPosition::Index(i) => i,
-        EndPosition::LastByte => {
-            file_size
-                .saturating_sub(1)
-                .min(start + MAX_UNBOUNDED_RANGE)
-        }
+        EndPosition::Index(i) => i.min(file_size.saturating_sub(1)),
+        EndPosition::LastByte => file_size
+            .saturating_sub(1)
+            .min(start + MAX_UNBOUNDED_RANGE),
     };
 
     // Validate the range
     if start > end || start >= file_size {
         return None;
     }
-
-    // Clamp end to file size
-    let end = end.min(file_size.saturating_sub(1));
 
     Some((start, end))
 }
@@ -501,18 +511,36 @@ pub async fn get_blob(
         _ => return Err(StatusCode::NOT_FOUND),
     };
 
+    // Never serve banned content, even if the physical file still exists.
+    if info.banned {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
     let file_path = state.fs.get(&id);
 
     // Check for Range header and handle range requests
     let range_header = headers.get(header::RANGE).and_then(|h| h.to_str().ok());
 
-    if let Some(range_str) = range_header
-        && let Some((start, end)) = get_range_from_header(range_str, info.size)
-    {
-        // Record range-request stats (bytes = range length).
-        let bytes_served = end - start + 1;
-        state.file_stats.record(&id, bytes_served, Utc::now());
-        return build_range_response(file_path, info, start, end).await;
+    if let Some(range_str) = range_header {
+        match get_range_from_header(range_str, info.size) {
+            Some((start, end)) => {
+                // Record range-request stats (bytes = range length).
+                let bytes_served = end - start + 1;
+                state.file_stats.record(&id, bytes_served, Utc::now());
+                return build_range_response(file_path, info, start, end).await;
+            }
+            None => {
+                // A Range header was sent but could not be satisfied — return
+                // 416 with the total size per RFC 7233.
+                let mut response = StatusCode::RANGE_NOT_SATISFIABLE.into_response();
+                if let Ok(v) = format!("bytes/*/{}", info.size).parse() {
+                    response
+                        .headers_mut()
+                        .insert(header::CONTENT_RANGE, v);
+                }
+                return Ok(response);
+            }
+        }
     }
 
     // Record full-file access stats.
@@ -578,6 +606,10 @@ pub async fn head_blob(
         _ => return Err(StatusCode::NOT_FOUND),
     };
 
+    if info.banned {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
     // Create a response with proper headers but no body (for HEAD request)
     let mut response = Response::new(Body::empty());
 
@@ -619,6 +651,10 @@ pub async fn get_blob_thumb(
         return Err(StatusCode::NOT_FOUND);
     };
 
+    if info.banned {
+        return Err(StatusCode::NOT_FOUND);
+    }
+
     if !(info.mime_type.starts_with("image/") || info.mime_type.starts_with("video/")) {
         return Err(StatusCode::NOT_FOUND);
     }
@@ -629,18 +665,63 @@ pub async fn get_blob_thumb(
     thumb_file.set_extension("webp");
 
     if !thumb_file.exists() {
-        let mut p = WebpProcessor::new();
-        if let Err(e) = p.thumbnail(&file_path, &thumb_file) {
-            warn!("Failed to generate thumbnail: {}", e);
-            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        // Serialize generation per file: concurrent requests for the same
+        // thumbnail must not race writing the same temp file.
+        let lock = {
+            let mut locks = THUMB_LOCKS.lock().await;
+            locks
+                .entry(sha256.to_string())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        let _guard = lock.lock().await;
+
+        // Re-check after acquiring the lock — another request may have just
+        // finished generating this thumbnail.
+        if !thumb_file.exists() {
+            // FFmpeg work is CPU-bound and blocking; run it off the async
+            // executor so we don't stall other requests. Write to a unique
+            // temp path first, then atomically rename into place.
+            let mut tmp_out = temp_dir().join(format!("thumb_{}_{}", sha256, uuid::Uuid::new_v4()));
+            tmp_out.set_extension("webp");
+            let src = file_path.clone();
+            let tmp = tmp_out.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let mut p = WebpProcessor::new();
+                p.thumbnail(&src, &tmp)
+            })
+            .await;
+            match result {
+                Ok(Ok(())) => {
+                    if let Err(e) = tokio::fs::rename(&tmp_out, &thumb_file).await {
+                        warn!("Failed to move thumbnail into place: {}", e);
+                        tokio::fs::remove_file(&tmp_out).await.ok();
+                        return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                    }
+                }
+                Ok(Err(e)) => {
+                    warn!("Failed to generate thumbnail: {}", e);
+                    tokio::fs::remove_file(&tmp_out).await.ok();
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                }
+                Err(e) => {
+                    warn!("Thumbnail task failed: {}", e);
+                    tokio::fs::remove_file(&tmp_out).await.ok();
+                    return Err(StatusCode::INTERNAL_SERVER_ERROR);
+                }
+            }
         }
     };
 
     if let Ok(f) = File::open(&thumb_file).await {
+        let size = match f.metadata().await {
+            Ok(m) => m.len(),
+            Err(_) => return Err(StatusCode::NOT_FOUND),
+        };
         Ok(FilePayload {
             file: f,
             info: FileUpload {
-                size: thumb_file.metadata().unwrap().len(),
+                size,
                 mime_type: "image/webp".to_string(),
                 ..info
             },

--- a/src/routes/nip96.rs
+++ b/src/routes/nip96.rs
@@ -118,7 +118,7 @@ impl Nip96UploadResult {
 
     pub fn success(msg: &str) -> Self {
         Nip96UploadResult {
-            status: "error".to_string(),
+            status: "success".to_string(),
             message: Some(msg.to_string()),
             ..Default::default()
         }
@@ -143,8 +143,23 @@ struct Nip96Form {
     no_transform: Option<bool>,
 }
 
+/// Drop guard that removes a temp upload file when the request ends,
+/// regardless of success or failure.
+struct TempFileGuard(PathBuf);
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        let path = self.0.clone();
+        tokio::spawn(async move {
+            tokio::fs::remove_file(path).await.ok();
+        });
+    }
+}
+
 impl Nip96Form {
-    async fn from_multipart(mut multipart: Multipart) -> Result<Self, String> {
+    async fn from_multipart(mut multipart: Multipart, max_bytes: u64) -> Result<Self, String> {
+        use tokio::io::AsyncWriteExt;
+
         let mut file_stream = None;
         let mut expiration = None;
         let mut size = 0;
@@ -153,7 +168,7 @@ impl Nip96Form {
         let mut content_type = None;
         let mut no_transform = None;
 
-        while let Some(field) = multipart
+        while let Some(mut field) = multipart
             .next_field()
             .await
             .map_err(|e| format!("Failed to get field: {}", e))?
@@ -163,18 +178,41 @@ impl Nip96Form {
                 "file" => {
                     let temp_id = Uuid::new_v4();
                     let tmp_path = temp_dir().join(temp_id.to_string());
-                    tokio::fs::write(
-                        &tmp_path,
-                        field.bytes().await.map_err(|e| {
-                            error!("Failed to write file: {}", e);
-                            "Failed to write temp file".to_string()
-                        })?,
-                    )
-                    .await
-                    .map_err(|e| {
+                    // Stream to disk with a hard byte cap so a chunked upload
+                    // with no Content-Length can't exhaust memory or disk.
+                    let mut file = match tokio::fs::File::create(&tmp_path).await {
+                        Ok(f) => f,
+                        Err(e) => {
+                            error!("Failed to create temp file: {}", e);
+                            return Err("Failed to write temp file".to_string());
+                        }
+                    };
+                    let mut written: u64 = 0;
+                    let write_result: Result<(), String> = async {
+                        while let Some(chunk) = field
+                            .chunk()
+                            .await
+                            .map_err(|e| format!("Failed to read field chunk: {}", e))?
+                        {
+                            written += chunk.len() as u64;
+                            if written > max_bytes {
+                                return Err("File too large".to_string());
+                            }
+                            file.write_all(&chunk)
+                                .await
+                                .map_err(|e| format!("Failed to write temp file: {}", e))?;
+                        }
+                        file.flush()
+                            .await
+                            .map_err(|e| format!("Failed to write temp file: {}", e))
+                    }
+                    .await;
+                    drop(file);
+                    if let Err(e) = write_result {
                         error!("Failed to write file: {}", e);
-                        "Failed to write temp file".to_string()
-                    })?;
+                        tokio::fs::remove_file(&tmp_path).await.ok();
+                        return Err(e);
+                    }
                     file_stream = Some(tmp_path);
                 }
                 "expiration" => {
@@ -254,17 +292,20 @@ async fn get_info_doc(AxumState(state): AxumState<Arc<AppState>>) -> Json<Nip96I
     })
 }
 
+#[cfg_attr(not(feature = "payments"), allow(unused_assignments))]
 async fn upload(
     auth: Nip98Auth,
     AxumState(state): AxumState<Arc<AppState>>,
     multipart: Multipart,
 ) -> Nip96Response {
-    let form = match Nip96Form::from_multipart(multipart).await {
+    let settings = state.settings().await;
+    let form = match Nip96Form::from_multipart(multipart, settings.max_upload_bytes).await {
         Ok(f) => f,
         Err(e) => return Nip96Response::error(&format!("Could not parse form: {}", e)),
     };
+    // Always remove the temp file when we're done with it.
+    let _tmp_guard = TempFileGuard(form.tmp_file.clone());
 
-    let settings = state.settings().await;
     let upload_size = auth.content_length.or(Some(form.size)).unwrap_or(0);
     if upload_size > 0 && upload_size > settings.max_upload_bytes {
         return Nip96Response::error("File too large");
@@ -321,9 +362,11 @@ async fn upload(
         }
     }
 
-    let Ok(temp_file) = tokio::fs::File::open(form.tmp_file).await else {
+    let Ok(temp_file) = tokio::fs::File::open(&form.tmp_file).await else {
         return Nip96Response::error("Failed to open temporary file");
     };
+    #[cfg_attr(not(feature = "payments"), allow(unused_variables))]
+    let mut is_new_file = false;
     let upload = match state
         .fs
         .put(
@@ -335,6 +378,7 @@ async fn upload(
         .await
     {
         Ok(FileSystemResult::NewFile(blob)) => {
+            is_new_file = true;
             let mut upload: FileUpload = (&blob).into();
 
             // Validate file size after upload if no pre-upload size was available
@@ -355,7 +399,12 @@ async fn upload(
             )));
         }
         Ok(FileSystemResult::AlreadyExists(i)) => match state.db.get_file(&i).await {
-            Ok(Some(f)) => f,
+            Ok(Some(f)) if !f.banned => f,
+            Ok(Some(_)) => {
+                return Nip96Response::Forbidden(Json(Nip96UploadResult::error(
+                    "File is not allowed on this server",
+                )));
+            }
             _ => return Nip96Response::error("File not found"),
         },
         Err(e) => {
@@ -369,10 +418,12 @@ async fn upload(
         Err(e) => return Nip96Response::error(&format!("Could not save user: {}", e)),
     };
 
-    // Post-upload quota check if we didn't have size information before upload (only if payments are configured)
+    // Post-upload quota check, using the actual stored size. The declared
+    // size is only a hint and is never trusted for quota enforcement.
     #[cfg(feature = "payments")]
-    if upload_size == 0 {
-        if let Some(payment_config) = &settings.payments {
+    {
+        let _ = upload_size;
+        if is_new_file && let Some(payment_config) = &settings.payments {
             let free_quota = payment_config.free_quota_bytes.unwrap_or(104857600); // Default to 100MB
 
             match state

--- a/src/routes/payment.rs
+++ b/src/routes/payment.rs
@@ -88,7 +88,20 @@ async fn req_payment(
         }
     };
 
-    let amount = btc_amount * req.units * req.quantity as f32;
+    // Clamp user-supplied quantities to sane bounds and compute the total in
+    // double precision — f32 arithmetic can round and overflow.
+    if !(req.units.is_finite() && req.units > 0.0 && req.units <= 1_000_000.0) {
+        return Err((StatusCode::BAD_REQUEST, "Invalid units".to_string()));
+    }
+    if req.quantity == 0 || req.quantity > 1000 {
+        return Err((StatusCode::BAD_REQUEST, "Invalid quantity".to_string()));
+    }
+
+    let amount = (btc_amount as f64) * (req.units as f64) * (req.quantity as f64);
+    if amount > 2_100_000_000_000_000.0 {
+        // > total BTC supply in sats — clearly bogus
+        return Err((StatusCode::BAD_REQUEST, "Amount too large".to_string()));
+    }
 
     let pubkey_vec = auth.event.pubkey.to_bytes().to_vec();
     let uid = state.db.upsert_user(&pubkey_vec).await.map_err(|_| {
@@ -105,7 +118,8 @@ async fn req_payment(
 
     let mut lnd = lnd_client.deref().clone();
     let c = lnd.lightning();
-    let msat = (amount * 1e11f32) as u64;
+    // amount is BTC-denominated satoshis as f64 (validated above); convert to msat.
+    let msat = (amount * 1e11f64) as u64;
     let memo = format!(
         "{}x {} {} for {}",
         req.quantity, req.units, cfg.unit, auth.event.pubkey

--- a/src/whitelist.rs
+++ b/src/whitelist.rs
@@ -64,8 +64,10 @@ impl Whitelist {
             WhitelistInner::Database(db) => match db.whitelist_contains(pubkey_hex).await {
                 Ok(found) => found,
                 Err(e) => {
-                    warn!("DB whitelist check failed, failing open: {}", e);
-                    true
+                    // Fail closed: a broken whitelist check must not silently
+                    // open the server to everyone.
+                    warn!("DB whitelist check failed, failing closed: {}", e);
+                    false
                 }
             },
         }


### PR DESCRIPTION
Full security / bug / performance audit pass across the request path (auth, routes, filesystem, db, background). Build is clean, all 103 lib tests pass, and no new clippy warnings are introduced.

## Security
- **Mirror SSRF guard** — `PUT /mirror` now rejects non-http(s) schemes and any host resolving to a private/loopback/link-local/CGNAT/reserved address (cloud metadata protection), with DNS-rebinding checks. Added reqwest connect/read timeouts and disabled redirects (previously an unbounded, timeout-less fetch).
- **NIP-96 memory-exhaustion DoS** — multipart uploads are now streamed to disk with a hard byte cap instead of buffering the whole body in memory; temp files are always cleaned up via a drop guard.
- **Panic on malformed Blossom auth expiration tag** — was an easily triggerable remote panic; now returns a proper 400.
- **Banned files** — no longer served (`GET`/`HEAD`/`thumb`) or re-accepted on upload.
- **Quota bypass** — quota is now always enforced against the actual stored size (was skippable by declaring `X-Content-Length`).
- **DB whitelist fails closed** on lookup errors (was failing open).
- **Content-Disposition** filename sanitized.
- **Report spam** — capped number of files per report.

## Bugs
- Removed MySQL-incompatible `RETURNING` in `upsert_user`.
- Fixed cursor pagination (was comparing raw hash bytes against the `created` timestamp — broken past page 1).
- `Nip96UploadResult::success()` no longer reports `"error"` status.
- Return `416` on unsatisfiable Range instead of a full `200`.
- First-admin `/setup` promotion made atomic (race).
- Delete now cleans up `file_stats` / `upload_labels` rows (no orphans).
- Stats deltas are re-recorded on flush failure instead of being lost.

## Performance
- FFmpeg compress/probe/thumbnail work moved to `spawn_blocking` (no longer blocks the async runtime).
- Thumbnail generation race-locked per hash + atomic write.
- Batched similar-files lookup (removed N+1).
- Payment inputs clamped; money math done in f64.

## Testing
- `cargo build` — clean
- `cargo test --lib` — 103 passed, 0 failed
- `cargo clippy --lib` — 0 new warnings (remaining 6 are pre-existing upstream)