### PR TITLE
Add ban-by-pubkey for admins

### DIFF
--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -324,6 +324,8 @@ Return detailed info for a user identified by their hex-encoded pubkey.
   "data": {
     "pubkey": "abc123...",
     "is_admin": false,
+    "banned": false,
+    "ban_reason": "spam",
     "file_count": 5,
     "total_size": 2097152,
     "created": "2025-06-01T12:00:00Z",
@@ -337,6 +339,42 @@ Return detailed info for a user identified by their hex-encoded pubkey.
     }
   }
 }
+```
+
+---
+
+### `POST /admin/user/{pubkey}/ban`
+
+Ban a pubkey. Banned pubkeys are rejected on every authenticated write path:
+Blossom upload, media, mirror, delete and report, and NIP-96 upload and delete.
+Existing files stay online; ban them separately if they must stop being served.
+
+The pubkey does not have to be known to the server; the user row is created on
+demand so a key can be banned before its first request. Admins cannot be banned
+(demote first), and you cannot ban yourself.
+
+**Request body** (optional)
+
+```json
+{ "reason": "spam" }
+```
+
+**Response**
+
+```json
+{ "status": "success", "message": "Banned abc123..." }
+```
+
+---
+
+### `DELETE /admin/user/{pubkey}/ban`
+
+Lift a ban and clear the stored reason.
+
+**Response**
+
+```json
+{ "status": "success", "message": "Unbanned abc123..." }
 ```
 
 ---

--- a/migrations/20260408000000_user_ban.sql
+++ b/migrations/20260408000000_user_ban.sql
@@ -1,0 +1,5 @@
+-- Ban flag for user pubkeys. Banned users are rejected on every authenticated
+-- write path (upload, mirror, delete, report).
+alter table users
+    add column banned     bit(1)       not null default 0,
+    add column ban_reason varchar(512) null;

--- a/src/db.rs
+++ b/src/db.rs
@@ -127,6 +127,8 @@ pub struct User {
     pub pubkey: Vec<u8>,
     pub created: DateTime<Utc>,
     pub is_admin: bool,
+    pub banned: bool,
+    pub ban_reason: Option<String>,
     #[cfg(feature = "payments")]
     pub paid_until: Option<DateTime<Utc>>,
     #[cfg(feature = "payments")]
@@ -241,6 +243,49 @@ impl Database {
         };
 
         Ok(user_id)
+    }
+
+    /// Ban a pubkey, blocking every authenticated write path.
+    ///
+    /// Inserts the user row if it does not exist yet, so a pubkey can be banned
+    /// before it has ever touched the API.
+    pub async fn ban_user(&self, pubkey: &Vec<u8>, reason: Option<&str>) -> Result<(), Error> {
+        let mut tx = self.pool.begin().await?;
+        // Insert ignore rather than an upsert: columns added by later migrations
+        // (paid_size) are NOT NULL without a default, which strict mode rejects
+        // unless the row insert is ignorable.
+        sqlx::query("insert ignore into users(pubkey, is_admin) values(?, 0)")
+            .bind(pubkey)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("update users set banned = 1, ban_reason = ? where pubkey = ?")
+            .bind(reason)
+            .bind(pubkey)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Lift a ban on `pubkey`. Does nothing if the user does not exist.
+    pub async fn unban_user(&self, pubkey: &Vec<u8>) -> Result<(), Error> {
+        sqlx::query("update users set banned = 0, ban_reason = null where pubkey = ?")
+            .bind(pubkey)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Returns `true` if `pubkey` is banned. Unknown pubkeys are not banned.
+    pub async fn is_user_banned(&self, pubkey: &Vec<u8>) -> Result<bool, Error> {
+        let row = sqlx::query("select banned from users where pubkey = ?")
+            .bind(pubkey)
+            .fetch_optional(&self.pool)
+            .await?;
+        match row {
+            Some(r) => r.try_get(0),
+            None => Ok(false),
+        }
     }
 
     /// Grant admin privileges to the user identified by `pubkey`.
@@ -475,6 +520,8 @@ impl Database {
                 pubkey: row.try_get("pubkey")?,
                 created: row.try_get("created")?,
                 is_admin: row.try_get("is_admin")?,
+                banned: row.try_get("banned")?,
+                ban_reason: row.try_get("ban_reason")?,
                 #[cfg(feature = "payments")]
                 paid_until: row.try_get("paid_until")?,
                 #[cfg(feature = "payments")]

--- a/src/routes/admin.rs
+++ b/src/routes/admin.rs
@@ -57,6 +57,10 @@ pub fn admin_routes() -> Router<Arc<AppState>> {
         .route("/admin/user/{user_pubkey}", get(admin_get_user_info))
         .route("/admin/user/{user_pubkey}/purge", delete(admin_purge_user))
         .route(
+            "/admin/user/{user_pubkey}/ban",
+            post(admin_ban_user).delete(admin_unban_user),
+        )
+        .route(
             "/admin/whitelist",
             get(admin_list_whitelist)
                 .post(admin_add_whitelist)
@@ -195,6 +199,9 @@ pub struct UserFile {
 pub struct AdminUserInfo {
     pub pubkey: String,
     pub is_admin: bool,
+    pub banned: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ban_reason: Option<String>,
     pub file_count: u64,
     pub total_size: u64,
     pub created: String,
@@ -242,6 +249,9 @@ async fn require_admin(auth: &Nip98Auth, db: &Database) -> Result<User, String> 
         .map_err(|_| "User not found".to_string())?;
     if !user.is_admin {
         return Err("User is not an admin".to_string());
+    }
+    if user.banned {
+        return Err("User is banned".to_string());
     }
     Ok(user)
 }
@@ -913,6 +923,8 @@ async fn admin_get_user_info(
     AdminResponse::success(AdminUserInfo {
         pubkey: hex::encode(&target_pubkey),
         is_admin: target_user.is_admin,
+        banned: target_user.banned,
+        ban_reason: target_user.ban_reason.clone(),
         file_count: user_stats.file_count,
         total_size: user_stats.total_size,
         created: target_user.created.to_rfc3339(),
@@ -932,6 +944,81 @@ async fn admin_get_user_info(
         payments,
         files: files_result,
     })
+}
+
+/// Request body for `POST /admin/user/{pubkey}/ban`.
+#[derive(Deserialize, Default)]
+struct AdminBanUserBody {
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+/// POST /admin/user/{pubkey}/ban — block a pubkey from all authenticated writes
+async fn admin_ban_user(
+    auth: Nip98Auth,
+    Path(user_pubkey): Path<String>,
+    AxumState(state): AxumState<Arc<AppState>>,
+    body: Option<Json<AdminBanUserBody>>,
+) -> AdminResponse<()> {
+    let admin = match require_admin(&auth, &state.db).await {
+        Ok(u) => u,
+        Err(e) => return AdminResponse::error(&e),
+    };
+
+    let target_pubkey = match hex::decode(&user_pubkey) {
+        Ok(pk) => pk,
+        Err(_) => return AdminResponse::error("Invalid pubkey format"),
+    };
+
+    if target_pubkey == admin.pubkey {
+        return AdminResponse::error("You cannot ban yourself");
+    }
+
+    // Banning an admin would let one operator lock out another; demote first.
+    if let Ok(target) = state.db.get_user(&target_pubkey).await
+        && target.is_admin
+    {
+        return AdminResponse::error("Cannot ban an admin user");
+    }
+
+    let reason = body
+        .map(|Json(b)| b.reason)
+        .unwrap_or_default()
+        .filter(|r| !r.trim().is_empty());
+
+    match state.db.ban_user(&target_pubkey, reason.as_deref()).await {
+        Ok(()) => AdminResponse::Ok(Json(AdminResponseBase {
+            status: "success".to_string(),
+            message: Some(format!("Banned {}", user_pubkey)),
+            data: None,
+        })),
+        Err(e) => AdminResponse::error(&format!("Failed to ban user: {}", e)),
+    }
+}
+
+/// DELETE /admin/user/{pubkey}/ban — lift a ban
+async fn admin_unban_user(
+    auth: Nip98Auth,
+    Path(user_pubkey): Path<String>,
+    AxumState(state): AxumState<Arc<AppState>>,
+) -> AdminResponse<()> {
+    if let Err(e) = require_admin(&auth, &state.db).await {
+        return AdminResponse::error(&e);
+    }
+
+    let target_pubkey = match hex::decode(&user_pubkey) {
+        Ok(pk) => pk,
+        Err(_) => return AdminResponse::error("Invalid pubkey format"),
+    };
+
+    match state.db.unban_user(&target_pubkey).await {
+        Ok(()) => AdminResponse::Ok(Json(AdminResponseBase {
+            status: "success".to_string(),
+            message: Some(format!("Unbanned {}", user_pubkey)),
+            data: None,
+        })),
+        Err(e) => AdminResponse::error(&format!("Failed to unban user: {}", e)),
+    }
 }
 
 async fn admin_purge_user(

--- a/src/routes/blossom.rs
+++ b/src/routes/blossom.rs
@@ -1,7 +1,8 @@
 use crate::auth::blossom::BlossomAuth;
 use crate::db::FileUpload;
 use crate::filesystem::FileSystemResult;
-use crate::routes::{AppState, Nip94Event, delete_file};
+use crate::db::Database;
+use crate::routes::{AppState, Nip94Event, ban_check, delete_file};
 use crate::settings::Settings;
 use crate::whitelist::Whitelist;
 use axum::{
@@ -322,13 +323,20 @@ fn check_method(event: &nostr::Event, method: &str) -> bool {
     false
 }
 
-async fn check_whitelist(auth: &BlossomAuth, whitelist: &Whitelist) -> Option<BlossomResponse> {
+async fn check_whitelist(
+    auth: &BlossomAuth,
+    whitelist: &Whitelist,
+    db: &Database,
+) -> Option<BlossomResponse> {
     if !whitelist.is_allowed(&auth.event.pubkey.to_hex()).await {
         return Some(BlossomResponse::Generic(BlossomGenericResponse {
             status: StatusCode::FORBIDDEN,
             message: Some("Not on whitelist".to_string()),
             payment_headers: None,
         }));
+    }
+    if let Some(msg) = ban_check(db, &auth.event.pubkey.to_bytes().to_vec()).await {
+        return Some(BlossomResponse::forbidden(msg));
     }
     None
 }
@@ -415,7 +423,14 @@ struct ListFilesParams {
 
 async fn upload_head(auth: BlossomAuth, AxumState(state): AxumState<Arc<AppState>>) -> BlossomHead {
     let settings = state.settings().await;
-    check_head(auth, &state.wl().await, &settings, &settings.public_url).await
+    check_head(
+        auth,
+        &state.wl().await,
+        &state.db,
+        &settings,
+        &settings.public_url,
+    )
+    .await
 }
 
 async fn upload(
@@ -453,7 +468,7 @@ async fn mirror(
         return e;
     }
     
-    if let Some(e) = check_whitelist(&auth, &state.wl().await).await {
+    if let Some(e) = check_whitelist(&auth, &state.wl().await, &state.db).await {
         return e;
     }
 
@@ -555,11 +570,24 @@ async fn mirror(
 #[cfg(feature = "media-compression")]
 async fn head_media(auth: BlossomAuth, AxumState(state): AxumState<Arc<AppState>>) -> BlossomHead {
     let settings = state.settings().await;
-    check_head_media(auth, &state.wl().await, &settings, &settings.public_url).await
+    check_head_media(
+        auth,
+        &state.wl().await,
+        &state.db,
+        &settings,
+        &settings.public_url,
+    )
+    .await
 }
 
 #[cfg(feature = "media-compression")]
-async fn check_head_media(auth: BlossomAuth, whitelist: &Whitelist, settings: &Settings, server_domain: &str) -> BlossomHead {
+async fn check_head_media(
+    auth: BlossomAuth,
+    whitelist: &Whitelist,
+    db: &Database,
+    settings: &Settings,
+    server_domain: &str,
+) -> BlossomHead {
     if !check_method(&auth.event, "media") {
         return BlossomHead {
             msg: Some("Invalid auth method tag"),
@@ -613,6 +641,16 @@ async fn check_head_media(auth: BlossomAuth, whitelist: &Whitelist, settings: &S
         };
     }
 
+    if ban_check(db, &auth.event.pubkey.to_bytes().to_vec())
+        .await
+        .is_some()
+    {
+        return BlossomHead {
+            msg: Some("Pubkey is banned"),
+            status: StatusCode::FORBIDDEN,
+        };
+    }
+
     // BUD-11: validate server tag
     if auth.validate_server_tag(server_domain).is_err() {
         return BlossomHead {
@@ -633,7 +671,13 @@ async fn upload_media(
     process_upload("media", true, auth, state, body).await
 }
 
-async fn check_head(auth: BlossomAuth, whitelist: &Whitelist, settings: &Settings, server_domain: &str) -> BlossomHead {
+async fn check_head(
+    auth: BlossomAuth,
+    whitelist: &Whitelist,
+    db: &Database,
+    settings: &Settings,
+    server_domain: &str,
+) -> BlossomHead {
     if !check_method(&auth.event, "upload") {
         return BlossomHead {
             msg: Some("Invalid auth method tag"),
@@ -683,6 +727,16 @@ async fn check_head(auth: BlossomAuth, whitelist: &Whitelist, settings: &Setting
     if !whitelist.is_allowed(&auth.event.pubkey.to_hex()).await {
         return BlossomHead {
             msg: Some("Not on whitelist"),
+            status: StatusCode::FORBIDDEN,
+        };
+    }
+
+    if ban_check(db, &auth.event.pubkey.to_bytes().to_vec())
+        .await
+        .is_some()
+    {
+        return BlossomHead {
+            msg: Some("Pubkey is banned"),
             status: StatusCode::FORBIDDEN,
         };
     }
@@ -737,7 +791,7 @@ async fn process_upload(
     }
 
     // check whitelist
-    if let Some(e) = check_whitelist(&auth, &state.wl().await).await {
+    if let Some(e) = check_whitelist(&auth, &state.wl().await, &state.db).await {
         return e;
     }
 
@@ -1060,6 +1114,10 @@ async fn report_file(
         .collect();
     if file_hashes.is_empty() {
         return BlossomResponse::bad_request("No valid file hashes in x tags");
+    }
+
+    if let Some(msg) = ban_check(&state.db, &data.pubkey.to_bytes().to_vec()).await {
+        return BlossomResponse::forbidden(msg);
     }
 
     // Get or create the reporter user from the report event pubkey

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -363,6 +363,21 @@ fn set_file_headers(response: &mut Response, info: &FileUpload) {
     }
 }
 
+/// Reason string if `pubkey` is banned from writing, `None` if allowed.
+///
+/// Fails closed like the whitelist check: a database error blocks the write
+/// rather than silently letting a banned pubkey through.
+pub async fn ban_check(db: &Database, pubkey: &Vec<u8>) -> Option<String> {
+    match db.is_user_banned(pubkey).await {
+        Ok(false) => None,
+        Ok(true) => Some("Pubkey is banned".to_string()),
+        Err(e) => {
+            warn!("Ban check failed, failing closed: {}", e);
+            Some("Could not verify ban status".to_string())
+        }
+    }
+}
+
 async fn delete_file(
     sha256: &str,
     auth: &Event,
@@ -385,6 +400,9 @@ async fn delete_file(
     }
     if let Ok(Some(_info)) = db.get_file(&id).await {
         let pubkey_vec = auth.pubkey.to_bytes().to_vec();
+        if let Some(msg) = ban_check(db, &pubkey_vec).await {
+            return Err(Error::msg(msg));
+        }
         let auth_user = db.get_user(&pubkey_vec).await?;
         let owners = db.get_file_owners(&id).await?;
         if auth_user.is_admin {

--- a/src/routes/nip96.rs
+++ b/src/routes/nip96.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use crate::auth::nip98::Nip98Auth;
 use crate::db::FileUpload;
 use crate::filesystem::FileSystemResult;
-use crate::routes::{AppState, Nip94Event, PagedResult, delete_file};
+use crate::routes::{AppState, Nip94Event, PagedResult, ban_check, delete_file};
 use crate::settings::Settings;
 use axum::{
     Json, Router,
@@ -343,6 +343,10 @@ async fn upload(
     }
 
     let pubkey_vec = auth.event.pubkey.to_bytes().to_vec();
+
+    if let Some(msg) = ban_check(&state.db, &pubkey_vec).await {
+        return Nip96Response::Forbidden(Json(Nip96UploadResult::error(&msg)));
+    }
 
     // check quota (only if payments are configured)
     #[cfg(feature = "payments")]

--- a/ui_src/src/upload/admin.ts
+++ b/ui_src/src/upload/admin.ts
@@ -34,6 +34,8 @@ export interface Route96File {
 export interface AdminUserInfo {
   pubkey: string;
   is_admin: boolean;
+  banned: boolean;
+  ban_reason?: string;
   file_count: number;
   total_size: number;
   created: string;
@@ -264,6 +266,22 @@ export class Route96 {
       "GET",
     );
     const data = await this.#handleResponse<AdminResponse<AdminUserInfo>>(rsp);
+    return data;
+  }
+
+  async banUser(pubkey: string, reason?: string) {
+    const rsp = await this.#req(
+      `admin/user/${pubkey}/ban`,
+      "POST",
+      JSON.stringify({ reason }),
+    );
+    const data = await this.#handleResponse<AdminResponse<void>>(rsp);
+    return data;
+  }
+
+  async unbanUser(pubkey: string) {
+    const rsp = await this.#req(`admin/user/${pubkey}/ban`, "DELETE");
+    const data = await this.#handleResponse<AdminResponse<void>>(rsp);
     return data;
   }
 

--- a/ui_src/src/views/user-scope.tsx
+++ b/ui_src/src/views/user-scope.tsx
@@ -15,6 +15,7 @@ export default function UserScope() {
   const [loading, setLoading] = useState(true);
   const [filesPage, setFilesPage] = useState(0);
   const [purging, setPurging] = useState(false);
+  const [banning, setBanning] = useState(false);
 
   const login = useLogin();
   const pub = usePublisher();
@@ -52,6 +53,36 @@ export default function UserScope() {
         });
     }
   }, [pub, self?.is_admin, pubkey, filesPage, url]);
+
+  async function handleToggleBan() {
+    if (!pub || !pubkey || !userInfo) return;
+
+    const r96 = new Route96(url, pub);
+    setError(undefined);
+
+    try {
+      if (userInfo.banned) {
+        if (!window.confirm("Lift the ban on this pubkey?")) return;
+        setBanning(true);
+        await r96.unbanUser(pubkey);
+      } else {
+        const reason = window.prompt(
+          "Ban this pubkey? Uploads, mirrors, deletes and reports will be rejected.\n\nReason (optional):",
+        );
+        if (reason === null) return;
+        setBanning(true);
+        await r96.banUser(pubkey, reason || undefined);
+      }
+
+      const response = await r96.getUserInfo(pubkey, filesPage, 50);
+      setUserInfo(response.data);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Failed to update ban";
+      setError(message);
+    } finally {
+      setBanning(false);
+    }
+  }
 
   async function handlePurgeUser() {
     if (!pub || !pubkey) return;
@@ -188,10 +219,37 @@ export default function UserScope() {
               <div className="text-yellow-400">Admin</div>
             </div>
           )}
+          {userInfo.banned && (
+            <div>
+              <label className="text-neutral-500">Status</label>
+              <div className="text-red-400">
+                Banned{userInfo.ban_reason ? `: ${userInfo.ban_reason}` : ""}
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Danger Zone */}
-        <div className="mt-4 pt-3 border-t border-neutral-800">
+        <div className="mt-4 pt-3 border-t border-neutral-800 space-y-2">
+          <div className="flex items-center justify-between bg-red-950/30 border border-red-900/50 rounded-sm p-2">
+            <div>
+              <div className="text-xs text-red-400">
+                {userInfo.banned ? "Banned" : "Ban Pubkey"}
+              </div>
+              <div className="text-xs text-red-500/70">
+                {userInfo.banned
+                  ? userInfo.ban_reason || "No reason recorded"
+                  : "Reject uploads, mirrors, deletes and reports"}
+              </div>
+            </div>
+            <button
+              onClick={handleToggleBan}
+              disabled={banning || userInfo.is_admin}
+              className="bg-red-600 hover:bg-red-500 disabled:bg-red-900 disabled:text-red-400 text-white px-2 py-1 rounded-sm text-xs"
+            >
+              {banning ? "..." : userInfo.banned ? "Unban" : "Ban"}
+            </button>
+          </div>
           <div className="flex items-center justify-between bg-red-950/30 border border-red-900/50 rounded-sm p-2">
             <div>
               <div className="text-xs text-red-400">Purge Account</div>


### PR DESCRIPTION
Admins can ban a pubkey, blocking every authenticated write path: Blossom upload/media/mirror/delete/report and NIP-96 upload/delete. Reads are unaffected; existing files stay served unless banned separately.

- `POST /admin/user/{pubkey}/ban` with optional `{"reason":"..."}`, `DELETE` to lift it
- `users.banned` + `users.ban_reason` migration; the user row is created on demand so a key can be banned before its first request
- Self-ban and banning an admin are refused, and a banned admin loses admin API access
- Ban/Unban control and status in the admin user view

Verified against a local MariaDB: migration applies through sqlx, upload returns 201 before the ban and 403 after, HEAD /upload also 403.